### PR TITLE
[feature] add form decoding

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,7 +1,6 @@
 // Stuff
 
 /*
-
 Package nvelope provides injection handlers that make building
 HTTP endpoints simple.  In combination with npoint and nject it
 provides a API endpoint framework.
@@ -25,6 +24,5 @@ an error return to cause a specific HTTP error code to be sent.
 CatchPanic makes it easy to turn panics into error returns.
 
 The provided example puts it all together.
-
 */
 package nvelope

--- a/example_middleware_test.go
+++ b/example_middleware_test.go
@@ -3,7 +3,7 @@ package nvelope_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"time"
@@ -92,7 +92,7 @@ func ExampleServiceWithMiddleware() {
 			fmt.Println("response error:", err)
 			return
 		}
-		b, err := ioutil.ReadAll(res.Body)
+		b, err := io.ReadAll(res.Body)
 		if err != nil {
 			fmt.Println("read error:", err)
 			return

--- a/example_minimalerror_test.go
+++ b/example_minimalerror_test.go
@@ -3,7 +3,7 @@ package nvelope_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 
@@ -38,7 +38,7 @@ func ExampleMinimalErrorHandler() {
 			fmt.Println("response error:", err)
 			return
 		}
-		b, err := ioutil.ReadAll(res.Body)
+		b, err := io.ReadAll(res.Body)
 		if err != nil {
 			fmt.Println("read error:", err)
 			return

--- a/example_mwhandler_test.go
+++ b/example_mwhandler_test.go
@@ -3,7 +3,7 @@ package nvelope_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"time"
@@ -92,7 +92,7 @@ func ExampleServiceWithMiddlewareHandler() {
 			fmt.Println("response error:", err)
 			return
 		}
-		b, err := ioutil.ReadAll(res.Body)
+		b, err := io.ReadAll(res.Body)
 		if err != nil {
 			fmt.Println("read error:", err)
 			return

--- a/example_test.go
+++ b/example_test.go
@@ -3,7 +3,7 @@ package nvelope_test
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -91,7 +91,7 @@ func Example() {
 			fmt.Println("response error:", err)
 			return
 		}
-		b, err := ioutil.ReadAll(res.Body)
+		b, err := io.ReadAll(res.Body)
 		if err != nil {
 			fmt.Println("read error:", err)
 			return

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -2,7 +2,7 @@ package nvelope_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/cookiejar"
 	"net/http/httptest"
@@ -35,10 +35,9 @@ func captureOutput(path string, f interface{}) func(string, ...mod) string {
 
 type mod func(*http.Request, *http.Client, *httptest.Server)
 
-// nolint:unused,deadcode
 func body(s string) mod {
 	return func(r *http.Request, cl *http.Client, ts *httptest.Server) {
-		r.Body = ioutil.NopCloser(strings.NewReader(s))
+		r.Body = io.NopCloser(strings.NewReader(s))
 	}
 }
 
@@ -80,7 +79,7 @@ func captureOutputFunc(out func(...interface{}), path string, f interface{}) fun
 			panic("jar")
 		}
 		// nolint:noctx
-		req, err := http.NewRequest("POST", ts.URL+url, ioutil.NopCloser(strings.NewReader("")))
+		req, err := http.NewRequest("POST", ts.URL+url, io.NopCloser(strings.NewReader("")))
 		if err != nil {
 			panic("request")
 		}
@@ -94,7 +93,7 @@ func captureOutputFunc(out func(...interface{}), path string, f interface{}) fun
 			out("response error:", err)
 			return
 		}
-		b, err := ioutil.ReadAll(res.Body)
+		b, err := io.ReadAll(res.Body)
 		if err != nil {
 			out("read error:", err)
 			return

--- a/middleware.go
+++ b/middleware.go
@@ -8,7 +8,9 @@ import (
 
 // MiddlewareBaseWriter acts as a translator.  In the Go world, there
 // are a bunch of packages that expect to use the wrapping
-// 	func(http.HandlerFunc) http.HandlerFunc
+//
+//	func(http.HandlerFunc) http.HandlerFunc
+//
 // pattern.  The func(http.HandlerFunc) http.HandlerFunc pattern is harder to
 // use and not as expressive as the patterns supported by
 // npoint and nvelope, but there may be code written
@@ -32,7 +34,9 @@ func MiddlewareBaseWriter(m ...func(http.HandlerFunc) http.HandlerFunc) nject.Pr
 
 // MiddlewareDeferredWriter acts as a translator.  In the Go world, there
 // are a bunch of packages that expect to use the wrapping
+//
 //	func(http.HandlerFunc) http.HandlerFunc
+//
 // pattern.  The func(http.HandlerFunc) http.HandlerFunc pattern is harder to
 // use and not as expressive as the patterns supported by
 // npoint and nvelope, but there may be code written
@@ -78,7 +82,9 @@ func combineMiddleware(m []func(http.HandlerFunc) http.HandlerFunc) func(http.Ha
 
 // MiddlewareHandlerBaseWriter acts as a translator.  In the Go world, there
 // are a bunch of packages that expect to use the wrapping
-// 	func(http.Handler) http.Handler
+//
+//	func(http.Handler) http.Handler
+//
 // pattern.  The func(http.HandlerFunc) http.HandlerFunc pattern is harder to
 // use and not as expressive as the patterns supported by
 // npoint and nvelope, but there may be code written
@@ -102,7 +108,9 @@ func MiddlewareHandlerBaseWriter(m ...func(http.Handler) http.Handler) nject.Pro
 
 // MiddlewareHandlerDeferredWriter acts as a translator.  In the Go world, there
 // are a bunch of packages that expect to use the wrapping
+//
 //	func(http.Handler) http.Handler
+//
 // pattern.  The func(http.Handler) http.Handler pattern is harder to
 // use and not as expressive as the patterns supported by
 // npoint and nvelope, but there may be code written


### PR DESCRIPTION
The `form` annotation didn't previously do anything.

It now does. On `query` parameters, if you say `form` or `formOnly` then if the body is `application/x-www-form-urlencoded` then it will decode the body and fill in the parameters from the body.

If `formOnly` is used, than that parameter will only come from the body and will not come from the query string.

This is somewhat backwards incompatible because previously `form` was defined but it didn't do anything.